### PR TITLE
Change Material from Enum to Trait representation

### DIFF
--- a/src/hittable.rs
+++ b/src/hittable.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use std::{ops::Neg, rc::Rc};
 
 use glam::DVec3;
 
@@ -9,11 +9,11 @@ pub struct HitRecord {
     pub normal: DVec3,
     pub t: f64,
     pub front_face: bool,
-    pub material: Material,
+    pub material: Rc<dyn Material>,
 }
 
 impl HitRecord {
-    pub fn new(ray: &Ray, outward_normal: DVec3, t: f64, material: Material) -> HitRecord {
+    pub fn new(ray: &Ray, outward_normal: DVec3, t: f64, material: Rc<dyn Material>) -> HitRecord {
         let point = ray.at(t);
         let front_face = ray.direction.dot(outward_normal).is_sign_negative();
         let normal = if front_face {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod renderer;
 mod sphere;
 mod utils;
 
+use std::rc::Rc;
+
 use camera::Camera;
 use glam::{dvec3, DVec3};
 use hittable::HittableList;
@@ -47,7 +49,7 @@ fn main() {
 fn random_scene() -> HittableList {
     let mut world = HittableList::new();
 
-    let material_ground = Material::Lambertian(Lambertian::new(dvec3(0.5, 0.5, 0.5)));
+    let material_ground = Rc::new(Lambertian::new(dvec3(0.5, 0.5, 0.5)));
     world.add(Box::new(Sphere::new(
         DVec3::new(0.0, -1000.0, 0.0),
         1000.0,
@@ -64,15 +66,15 @@ fn random_scene() -> HittableList {
             );
 
             if (center - dvec3(4.0, 0.2, 0.0)).length() > 0.9 {
-                let material = if choose_mat < 0.8 {
+                let material: Rc<dyn Material> = if choose_mat < 0.8 {
                     let albedo = random_color() * random_color();
-                    Material::Lambertian(Lambertian::new(albedo))
+                    Rc::new(Lambertian::new(albedo))
                 } else if choose_mat < 0.95 {
                     let albedo = random_color_range(0.5, 1.0);
                     let fuzz = random::<f64>() * 0.5;
-                    Material::Metal(Metal::new(albedo, fuzz))
+                    Rc::new(Metal::new(albedo, fuzz))
                 } else {
-                    Material::Dialectric(Dialectric::new(1.5))
+                    Rc::new(Dialectric::new(1.5))
                 };
                 world.add(Box::new(Sphere::new(center, 0.2, material)));
             }
@@ -80,21 +82,21 @@ fn random_scene() -> HittableList {
     }
 
     let large_sphere_radius = 1.0;
-    let glass_material = Material::Dialectric(Dialectric::new(1.5));
+    let glass_material = Rc::new(Dialectric::new(1.5));
     world.add(Box::new(Sphere::new(
         dvec3(0.0, 1.0, 0.0),
         large_sphere_radius,
         glass_material,
     )));
 
-    let diffuse_material = Material::Lambertian(Lambertian::new(dvec3(0.4, 0.2, 0.1)));
+    let diffuse_material = Rc::new(Lambertian::new(dvec3(0.4, 0.2, 0.1)));
     world.add(Box::new(Sphere::new(
         dvec3(-4.0, 1.0, 0.0),
         large_sphere_radius,
         diffuse_material,
     )));
 
-    let metal_material = Material::Metal(Metal::new(dvec3(0.7, 0.6, 0.5), 0.0));
+    let metal_material = Rc::new(Metal::new(dvec3(0.7, 0.6, 0.5), 0.0));
     world.add(Box::new(Sphere::new(
         dvec3(4.0, 1.0, 0.0),
         large_sphere_radius,

--- a/src/materials/dialectric.rs
+++ b/src/materials/dialectric.rs
@@ -6,7 +6,7 @@ use rand::random;
 use crate::{hittable::HitRecord, ray::Ray};
 
 use super::{
-    material::{ScatterRecord, Scatterable},
+    material::{Material, ScatterRecord},
     utils,
 };
 
@@ -29,7 +29,7 @@ impl Dialectric {
     }
 }
 
-impl Scatterable for Dialectric {
+impl Material for Dialectric {
     fn scatter(&self, ray: &Ray, hit_record: &HitRecord) -> Option<ScatterRecord> {
         let attenuation = dvec3(1.0, 1.0, 1.0);
         let refraction_ratio = if hit_record.front_face {

--- a/src/materials/lambertian.rs
+++ b/src/materials/lambertian.rs
@@ -3,7 +3,7 @@ use glam::DVec3;
 use crate::{hittable::HitRecord, ray::Ray, utils};
 
 use super::{
-    material::{ScatterRecord, Scatterable},
+    material::{Material, ScatterRecord},
     utils::random_unit_vector,
 };
 
@@ -18,7 +18,7 @@ impl Lambertian {
     }
 }
 
-impl Scatterable for Lambertian {
+impl Material for Lambertian {
     fn scatter(&self, _ray: &Ray, hit_record: &HitRecord) -> Option<ScatterRecord> {
         let scatter_direction = hit_record.normal + random_unit_vector();
         // Catch degenerate scatter directions

--- a/src/materials/material.rs
+++ b/src/materials/material.rs
@@ -2,31 +2,12 @@ use glam::DVec3;
 
 use crate::{hittable::HitRecord, ray::Ray};
 
-use super::{dialectric::Dialectric, lambertian::Lambertian, metal::Metal};
-
-#[derive(Clone, Copy)]
-pub enum Material {
-    Lambertian(Lambertian),
-    Metal(Metal),
-    Dialectric(Dialectric),
-}
-
 pub struct ScatterRecord {
     pub attenuation: DVec3,
     pub ray: Ray,
 }
 
-pub trait Scatterable {
+pub trait Material {
     /// Returns None if the ray is absorbed and not scattered
     fn scatter(&self, ray: &Ray, hit_record: &HitRecord) -> Option<ScatterRecord>;
-}
-
-impl Scatterable for Material {
-    fn scatter(&self, ray: &Ray, hit_record: &HitRecord) -> Option<ScatterRecord> {
-        match self {
-            Material::Lambertian(mat) => mat.scatter(ray, hit_record),
-            Material::Metal(mat) => mat.scatter(ray, hit_record),
-            Material::Dialectric(mat) => mat.scatter(ray, hit_record),
-        }
-    }
 }

--- a/src/materials/metal.rs
+++ b/src/materials/metal.rs
@@ -3,7 +3,7 @@ use glam::DVec3;
 use crate::{hittable::HitRecord, ray::Ray};
 
 use super::{
-    material::{ScatterRecord, Scatterable},
+    material::{Material, ScatterRecord},
     utils,
 };
 
@@ -22,7 +22,7 @@ impl Metal {
     }
 }
 
-impl Scatterable for Metal {
+impl Material for Metal {
     fn scatter(&self, ray: &Ray, hit_record: &HitRecord) -> Option<ScatterRecord> {
         let reflected = utils::reflect(ray.direction.normalize(), hit_record.normal);
         let scattered = Ray::new(

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,6 +1,6 @@
 use glam::{dvec3, DVec3};
 
-use crate::{hittable::HittableList, materials::material::Scatterable};
+use crate::hittable::HittableList;
 
 pub struct Ray {
     pub origin: DVec3,

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use glam::DVec3;
 
 use crate::{
@@ -9,11 +11,11 @@ use crate::{
 pub struct Sphere {
     pub center: DVec3,
     pub radius: f64,
-    pub material: Material,
+    pub material: Rc<dyn Material>,
 }
 
 impl Sphere {
-    pub fn new(center: DVec3, radius: f64, material: Material) -> Sphere {
+    pub fn new(center: DVec3, radius: f64, material: Rc<dyn Material>) -> Sphere {
         Sphere {
             center,
             radius,
@@ -44,6 +46,6 @@ impl Hittable for Sphere {
         let t = root;
         let point = ray.at(root);
         let normal = (point - self.center) / self.radius;
-        Some(HitRecord::new(&ray, normal, t, self.material))
+        Some(HitRecord::new(&ray, normal, t, self.material.clone()))
     }
 }


### PR DESCRIPTION
Changes the Scatterable trait to the Material trait, and does away with the Material enum, favoring Box<dyn Material> or Rc<dyn Material>.

This will let consumers of this library define their own materials, and gets rid of enum-related boilerplate code that wasn't doing anything for us, since we treat each "variant" the same, only needing the scatter() record.